### PR TITLE
change `gray` to `greys` due to colormap change

### DIFF
--- a/do-colorize.js
+++ b/do-colorize.js
@@ -57,7 +57,7 @@ function doColorize(img, options, cb) {
       opts.colormap = options.colormap
     }
     if(gray) {
-      opts.colormap = "gray"
+      opts.colormap = "greys"
     }
     var result = colorize(img, opts)
     cb(result)


### PR DESCRIPTION
It looks like the colormap package has changed and `gray` isn't defined anymore.

https://github.com/bpostlethwaite/colormap/commit/9b9200023327a1e8c950839ef8863502343f0a0c
